### PR TITLE
fix negated visibility test for resource name form field

### DIFF
--- a/ckanext/smdh/templates/package/snippets/resource_form.html
+++ b/ckanext/smdh/templates/package/snippets/resource_form.html
@@ -2,7 +2,7 @@
 
 
 {% block basic_fields_name %}
-  {% if data.id %}
+  {% if not data.id %}
     {{ super() }}
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
This field should only be shown in new resource forms.