### PR TITLE
Namespaced package names

### DIFF
--- a/ckanext/smdh/dataset_form_plugin.py
+++ b/ckanext/smdh/dataset_form_plugin.py
@@ -1,0 +1,30 @@
+import logging
+
+import ckan.plugins as plugins
+import ckan.plugins.toolkit as toolkit
+
+from ckanext.smdh import validators
+
+
+logger = logging.getLogger(__name__)
+
+
+class SmdhDatasetFormPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
+    plugins.implements(plugins.IDatasetForm)
+
+    # IDatasetForm
+
+    def _update_schema(self, schema, model):
+        return schema
+
+    def update_package_schema(self):
+        schema = super().update_package_schema()
+        schema['name'].append(validators.no_update_to_model_name('package'))
+        schema['resources']['name'].append(validators.no_update_to_resource_name)
+        return schema
+
+    def is_fallback(self):
+        return True
+
+    def package_types(self):
+        return []

--- a/ckanext/smdh/group_form_plugin.py
+++ b/ckanext/smdh/group_form_plugin.py
@@ -1,0 +1,27 @@
+import logging
+
+import ckan.plugins as plugins
+import ckan.plugins.toolkit as toolkit
+
+from ckanext.smdh import helpers
+from ckanext.smdh import validators
+
+
+logger = logging.getLogger(__name__)
+
+
+class SmdhGroupFormPlugin(plugins.SingletonPlugin, toolkit.DefaultGroupForm):
+    plugins.implements(plugins.IGroupForm)
+
+    # IGroupForm
+
+    def update_group_schema(self):
+        schema = super().update_group_schema()
+        schema['name'].append(validators.no_update_to_model_name('group'))
+        return schema
+
+    def is_fallback(self):
+        return True
+
+    def group_types(self):
+        return []

--- a/ckanext/smdh/helpers.py
+++ b/ckanext/smdh/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from ckan.plugins import toolkit
+from ckan.lib.helpers import can_update_owner_org as default_can_update_owner_org
 
 c = toolkit.c
 
@@ -19,3 +20,43 @@ def getTracking(packageid):
         return packageInfo["tracking_summary"]["recent"]
     else:
         return False
+
+def can_update_owner_org(data, orgs):
+    # This function overrides the default can_update_owner_org provided by ckan
+    # to disallow update of owner org for existing packages.
+    if 'id' in data:
+        return False
+    return default_can_update_owner_org(data, orgs)
+
+PACKAGE_NAMESPACE_SEPARATOR = '--'
+
+def convert_global_package_name_to_local(name):
+    """
+    Convert a package name from a globally unique name to a name that's only unique within the organization.
+
+    The returned name can only be used to create packages but not to read, update or delete them.
+    """
+    return name.rsplit(PACKAGE_NAMESPACE_SEPARATOR, maxsplit=1)[-1]
+
+def convert_local_package_name_to_global(organization_name, name):
+    """
+    Convert a package name from one that's only unique within the organization list of datasets to a globally unique name.
+
+    The returned name can be used to perform all CRUD operations on a dataset.
+    Local names cannot contain the sequence of characters '--' as they are used to add a namespace for the local package name.
+    """
+    if PACKAGE_NAMESPACE_SEPARATOR in name:
+        raise ValueError("local package name must not contain '--'")
+    return f'{organization_name}{PACKAGE_NAMESPACE_SEPARATOR}{name}'
+
+def ensure_global_package_name(organization_name, name):
+    """
+    Converts a package name to a globally unique one.
+
+    If this is a global name already the returned value is the same as `name` otherwise
+    the name is converted to a global one.
+    """
+    namespace_prefix = f'{organization_name}{PACKAGE_NAMESPACE_SEPARATOR}'
+    if name.startswith(namespace_prefix):
+        name = name[len(namespace_prefix):]
+    return convert_local_package_name_to_global(organization_name, name)

--- a/ckanext/smdh/plugin.py
+++ b/ckanext/smdh/plugin.py
@@ -38,8 +38,13 @@ class SmdhPlugin(plugins.SingletonPlugin):
 
     # ITemplateHelpers
     def get_helpers(self):
-        return {'isAdmin': helpers.isAdmin,
-        'getTracking': helpers.getTracking
+        return {
+            'isAdmin': helpers.isAdmin,
+            'getTracking': helpers.getTracking,
+            'can_update_owner_org': helpers.can_update_owner_org,
+            'convert_local_package_name_to_global': helpers.convert_local_package_name_to_global,
+            'convert_global_package_name_to_local': helpers.convert_global_package_name_to_local,
+            'ensure_global_package_name': helpers.ensure_global_package_name,
         }
 
     # IPackageController
@@ -56,4 +61,7 @@ class SmdhPlugin(plugins.SingletonPlugin):
         return {
             validators.no_update_to_model_name.__name__: validators.no_update_to_model_name,
             validators.no_update_to_resource_name.__name__: validators.no_update_to_resource_name,
+            validators.no_update_to_package_owner_org.__name__: validators.no_update_to_package_owner_org,
+            validators.convert_global_package_name_to_local.__name__: validators.convert_global_package_name_to_local,
+            validators.ensure_global_package_name.__name__: validators.ensure_global_package_name,
         }

--- a/ckanext/smdh/templates/package/snippets/package_basic_fields.html
+++ b/ckanext/smdh/templates/package/snippets/package_basic_fields.html
@@ -2,8 +2,10 @@
 
 {% block package_basic_fields_url %}
 {% set prefix = h.url_for('dataset.read', id='') %}
+{% set prefix = prefix if data.id else prefix ~ h.convert_local_package_name_to_global('<organization>', '') %}
 {% set domain = h.url_for('dataset.read', id='', qualified=true) %}
 {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+{% set domain = domain if data.id else domain ~ h.convert_local_package_name_to_global('<organization>', '') %}
 {% set attrs = {'data-module': 'slug-preview-slug', 'data-module-prefix': domain, 'data-module-placeholder': '<dataset>', 'data-module-package-id': data.id, 'class': 'form-control input-sm'} %}
   {{ form.prepend('name', id='field-name', label=_('URL'), prepend=prefix, placeholder=_('eg. my-dataset'), value=data.name, error=errors.name, attrs=attrs, is_required=true, disabled=true if data.id else false) }}
 {% endblock %}

--- a/ckanext/smdh/validators.py
+++ b/ckanext/smdh/validators.py
@@ -1,5 +1,7 @@
 from ckan.plugins import toolkit
 
+from . import helpers as h
+
 
 def no_update_to_model_name(model_key: str):
     def validator(value, context):
@@ -23,3 +25,28 @@ def no_update_to_resource_name(key, data, errors, context):
         errors[key].append(
             f'Cannot change value of key from {before_name[0]} to {data[key]}. This key is read-only'
         )
+
+def no_update_to_package_owner_org(value, context):
+    model = context.get('package')
+    if model and model.owner_org != value:
+        raise toolkit.Invalid(
+            f'Cannot change the owner organization for dataset'
+        )
+    return value
+
+def convert_global_package_name_to_local(value, context):
+    return h.convert_global_package_name_to_local(value)
+
+def ensure_global_package_name(key, data, errors, context):
+    model = context['model']
+    session = context['session']
+
+    if data[key] is toolkit.missing or not data[key]:
+        return
+
+    query = session.query(model.Group.name).filter_by(id=data[('owner_org',)])
+    org_name = query.first().name
+    try:
+        data[key] = h.ensure_global_package_name(org_name, data[key])
+    except ValueError:
+        errors[key].append("URL must not contain '--'")

--- a/ckanext/smdh/validators.py
+++ b/ckanext/smdh/validators.py
@@ -1,0 +1,25 @@
+from ckan.plugins import toolkit
+
+
+def no_update_to_model_name(model_key: str):
+    def validator(value, context):
+        model = context.get(model_key)
+        if model and model.name != value:
+            raise toolkit.Invalid(
+                f'Cannot change value of key from {model.name} to {value}. This key is read-only'
+            )
+        return value
+    return validator
+
+def no_update_to_resource_name(key, data, errors, context):
+    resource_id = data.get(key[:-1] + ('id',))
+    if not resource_id:
+        return
+
+    session = context['session']
+    model = context['model']
+    before_name = session.query(model.Resource.name).filter_by(id=resource_id).first()
+    if before_name and before_name[0] != data[key]:
+        errors[key].append(
+            f'Cannot change value of key from {before_name[0]} to {data[key]}. This key is read-only'
+        )

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,8 @@ setup(
     entry_points='''
         [ckan.plugins]
         smdh=ckanext.smdh.plugin:SmdhPlugin
+        smdh_dataset_form=ckanext.smdh.dataset_form_plugin:SmdhDatasetFormPlugin
+        smdh_group_form=ckanext.smdh.group_form_plugin:SmdhGroupFormPlugin
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan


### PR DESCRIPTION
These changes fix a conflict in method resolution for the group and form dataset by splitting the plugin, and introduce the concept of a global and local package names to support our S3 cloud storage convention, as package names may be reused across organizations.

Global package names are globally unique within CKAN, they identify the package and can be used to perform all CRUD operations on a package.

Local package names are only unique within the set of an organization's datasets. They can only be used to create packages as the implementation internally maps the name into a global one.

The transformation is based on prefixing the organization name to the local package name and separating them with '--' to create a globally unique name (since organization names are unique).

This mapping is completely transparent to the users and doesn't require special handling on extensions, unless an extension needs to map between S3 storage path and package names within ckan, in which case 3 helper methods are provided to convert between the two.