### PR TITLE
fix editing organization fails with missing name field

### DIFF
--- a/ckanext/smdh/assets/js/slug-preview.override.js
+++ b/ckanext/smdh/assets/js/slug-preview.override.js
@@ -56,7 +56,7 @@ this.ckan.module('slug-preview-slug', function (jQuery) {
         preview = parent.slugPreview({
           prefix: options.prefix,
           placeholder: options.placeholder,
-          editable: !slug[0].disabled,
+          editable: !slug[0].disabled && !slug[0].readOnly,
           i18n: {
             'URL': this._('URL'),
             'Edit': this._('Edit')

--- a/ckanext/smdh/templates/macros/form.html
+++ b/ckanext/smdh/templates/macros/form.html
@@ -201,7 +201,7 @@ options     - A list/tuple of fields to be used as <options>.
   {% call input_block(id or name, label or name, error='', classes=classes, extra_html=extra_html, is_required=is_required) %}
     <div class="input-group">
       {% if prepend %}<span class="input-group-addon">{{ prepend }}</span>{%- endif -%}
-      <input id="{{ id or name }}" type="{{ type }}" name="{{ name }}" value="{{ value | empty_and_escape }}" placeholder="{{ placeholder }}" {% if disabled %} disabled {% endif %} {{ attributes(attrs) }} />
+      <input id="{{ id or name }}" type="{{ type }}" name="{{ name }}" value="{{ value | empty_and_escape }}" placeholder="{{ placeholder }}" {% if disabled %} readonly {% endif %} {{ attributes(attrs) }} />
       {% if error and error is iterable %}<span class="error-block">{{ error|join(', ') }}</span>{% endif %}
     </div>
   {% endcall %}


### PR DESCRIPTION
use readonly input instead of disabled to include the value in form submission