### PR TITLE
fix no longer supported solr image in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       image: openknowledge/ckan-dev:2.9
     services:
       solr:
-        image: ckan/ckan-solr-dev:2.9
+        image: ckan/ckan-solr:2.9-solr8
       postgres:
         image: ckan/ckan-postgres-dev:2.9
         env:


### PR DESCRIPTION
replace the no longer supported tag 2.9 with 2.9-solr8