### PR TITLE
Minor UI updates

### DIFF
--- a/ckanext/smdh/templates/package/resource_read.html
+++ b/ckanext/smdh/templates/package/resource_read.html
@@ -1,7 +1,49 @@
 {% ckan_extends %}
 
 {% block resource_actions_inner %}
-    {{ super() }}
+    {% if h.check_access('package_update', {'id':pkg.id }) and not is_activity_archive %}
+    <li>{% link_for _('Manage'), named_route=pkg.type ~ '_resource.edit', id=pkg.name, resource_id=res.id, class_='btn
+        btn-default', icon='wrench' %}</li>
+    {% endif %}
+    {% if res.url and h.is_url(res.url) %}
+    <li>
+        <div class="btn-group">
+            <a class="btn btn-primary resource-url-analytics resource-type-{{ res.resource_type }}" href="{{ res.url }}">
+                {% if res.resource_type in ('listing', 'service') %}
+                <i class="fa fa-eye"></i> {{ _('View') }}
+                {% elif res.resource_type == 'api' %}
+                <i class="fa fa-key"></i> {{ _('API Endpoint') }}
+                {% elif not res.has_views and not res.url_type == 'upload' %}
+                <i class="fa fa-external-link"></i> {{ _('Go to resource') }}
+                {% elif not h.is_stream_resource(res) %}
+                <i class="fa fa-arrow-circle-o-down"></i> {{ _('Download') }}
+                {% else %}
+                <i class="fa fa-arrow-circle-o-down"></i> Download Preview
+                {% endif %}
+            </a>
+            {% block download_resource_button %}
+            {% if res.datastore_active %}
+            <button class="btn btn-primary dropdown-toggle" data-toggle="dropdown">
+                <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu">
+                <li>
+                    <a href="{{ h.url_for('datastore.dump', resource_id=res.id, bom=True) }}"
+                        target="_blank"><span>CSV</span></a>
+                    <a href="{{ h.url_for('datastore.dump', resource_id=res.id, format='tsv', bom=True) }}"
+                        target="_blank"><span>TSV</span></a>
+                    <a href="{{ h.url_for('datastore.dump', resource_id=res.id, format='json') }}"
+                        target="_blank"><span>JSON</span></a>
+                    <a href="{{ h.url_for('datastore.dump', resource_id=res.id, format='xml') }}"
+                        target="_blank"><span>XML</span></a>
+                </li>
+            </ul>
+            {% endif %}
+            {% endblock %}
+        </div>
+    </li>
+    {% endif %}
+
     {% if h.check_access('package_update', {'id':pkg.id }) and not is_activity_archive %}
         <li>
             {% set loading_text = _('Loading...') %}

--- a/ckanext/smdh/templates/package/snippets/resource_item.html
+++ b/ckanext/smdh/templates/package/snippets/resource_item.html
@@ -1,0 +1,15 @@
+{% ckan_extends %}
+
+{% block resource_item_explore_links %}
+    {{ super() }}
+    {% if h.check_access('package_update', {'id':pkg.id }) and not is_activity_archive %}
+    <li>
+        {% set loading_text = _('Loading...') %}
+        {% set api_info_url = h.url_for(controller='api', action='snippet', ver=1, snippet_path='api_popup.html',
+        resource_id=res.id) %}
+        <a href="{{ api_info_url }}" data-module="api-info"
+            data-module-template="/api/1/util/snippet/api_popup.html?resource_id={{ res.id }}"
+            data-loading-text="{{ loading_text }}"><i class="fa fa-flask"></i> {{ _('Data API') }}</a>
+    </li>
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
Currently, the added "Data API" link doesn't show because the template is overrided by the [generalpublic plugin](https://github.com/SmdhMdep/ckanext-generalpublic/blob/e8e1f1e17d9b586c156e92416363887cca2467c8/ckanext/generalpublic/templates/package/snippets/resource_item.html).

Depends on https://github.com/SmdhMdep/ckanext-generalpublic/pull/8